### PR TITLE
Add network error handling

### DIFF
--- a/NewsCatcher.xcodeproj/project.pbxproj
+++ b/NewsCatcher.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		EF85DBA02A9F5A2E00CD9295 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EF85DB9F2A9F5A2E00CD9295 /* Assets.xcassets */; };
 		EF85DBA32A9F5A2E00CD9295 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EF85DBA12A9F5A2E00CD9295 /* LaunchScreen.storyboard */; };
 		EF85DBAB2A9F7A6700CD9295 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF85DBAA2A9F7A6700CD9295 /* FeedView.swift */; };
+		EF91997C2AB99888000A6364 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF91997B2AB99888000A6364 /* NetworkError.swift */; };
 		EFF046B82AB0939F00121D66 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = EFF046B72AB0939F00121D66 /* .swiftlint.yml */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +64,7 @@
 		EF85DBA22A9F5A2E00CD9295 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		EF85DBA42A9F5A2E00CD9295 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EF85DBAA2A9F7A6700CD9295 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
+		EF91997B2AB99888000A6364 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		EFF046B72AB0939F00121D66 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -112,6 +114,7 @@
 				EF28C5122AA1CF2F00B68649 /* NetworkService.swift */,
 				EF2897CC2AA7210000B9A335 /* APIRequestBuilder.swift */,
 				EF28C5142AA1CFFC00B68649 /* News.swift */,
+				EF91997B2AB99888000A6364 /* NetworkError.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -304,6 +307,7 @@
 			files = (
 				EF2E828D2AABA3280065F4C5 /* NewsCatcherAssembly.swift in Sources */,
 				EF28C5202AA3432700B68649 /* ArticleViewController.swift in Sources */,
+				EF91997C2AB99888000A6364 /* NetworkError.swift in Sources */,
 				EF85DBAB2A9F7A6700CD9295 /* FeedView.swift in Sources */,
 				EF28C50C2AA06D9A00B68649 /* FeedCell.swift in Sources */,
 				EF85DB9B2A9F5A2C00CD9295 /* FeedViewController.swift in Sources */,

--- a/NewsCatcher/ArticleModule/ArticlePresenter.swift
+++ b/NewsCatcher/ArticleModule/ArticlePresenter.swift
@@ -43,9 +43,13 @@ final class ArticlePresenter: ArticleOutput {
     }
 
     func getImageData(atIndex index: Int, completion: @escaping (Data?) -> Void) {
-        dataManager.getImageDataForArticle(at: index) { data in
-            guard let data = data else { return }
-            completion(data)
+        dataManager.getImageDataForArticle(at: index) { result in
+            switch result {
+            case let .success(imageData): completion(imageData)
+            case let .failure(error):
+                self.handleError(error)
+                completion(nil)
+            }
         }
     }
 
@@ -54,6 +58,16 @@ final class ArticlePresenter: ArticleOutput {
         let urlString = dataManager.getSourceURLForArticle(at: index)
         if let url = URL(string: urlString) {
             view?.goToWebArticle(sourceURL: url)
+        }
+    }
+}
+
+extension ArticlePresenter {
+    private func handleError(_ error: NetworkError) {
+        // TODO: Create error handling cases
+        switch error {
+        default:
+            debugPrint(error.localizedDescription)
         }
     }
 }

--- a/NewsCatcher/DataManager/DataManager.swift
+++ b/NewsCatcher/DataManager/DataManager.swift
@@ -9,12 +9,12 @@ import Foundation
 
 protocol AppDataManager {
     var onDataUpdate: (() -> Void)? { get set }
-    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?)
+    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void))
     func getNumberOfArticles() -> Int
     func getTitleForArticle(at index: Int) -> String
     func getDescriptionForArticle(at index: Int) -> String
     func getContentForArticle(at index: Int) -> String
-    func getImageDataForArticle(at index: Int, completion: @escaping (Data?) -> Void)
+    func getImageDataForArticle(at index: Int, completion: @escaping (Result<Data, NetworkError>) -> Void)
     func getSourceURLForArticle(at index: Int) -> String
     func getSourceNameForArticle(at index: Int) -> String
     func getPublishingDateForArticle(at index: Int) -> String
@@ -55,10 +55,15 @@ final class DataManager: AppDataManager {
 
     // MARK: AppDataManager API
 
-    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?) {
-        repository.downloadNews(about: keyword, searchCriteria: searchCriteria) { [weak self] in
+    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void)) {
+        repository.downloadNews(about: keyword, searchCriteria: searchCriteria) { [weak self] result in
             guard let self else { return }
-            onDataUpdate?()
+            switch result {
+            case let .failure(error):
+                completion(.failure(error))
+            default:
+                onDataUpdate?()
+            }
         }
     }
 
@@ -78,7 +83,7 @@ final class DataManager: AppDataManager {
         repository.getContentForArticle(at: index)
     }
 
-    func getImageDataForArticle(at index: Int, completion: @escaping (Data?) -> Void) {
+    func getImageDataForArticle(at index: Int, completion: @escaping (Result<Data, NetworkError>) -> Void) {
         repository.getImageDataForArticle(at: index, completion: completion)
     }
 

--- a/NewsCatcher/DataManager/DataManager.swift
+++ b/NewsCatcher/DataManager/DataManager.swift
@@ -59,10 +59,10 @@ final class DataManager: AppDataManager {
         repository.downloadNews(about: keyword, searchCriteria: searchCriteria) { [weak self] result in
             guard let self else { return }
             switch result {
+            case .success(_):
+                onDataUpdate?()
             case let .failure(error):
                 completion(.failure(error))
-            default:
-                onDataUpdate?()
             }
         }
     }

--- a/NewsCatcher/DataManager/DataManager.swift
+++ b/NewsCatcher/DataManager/DataManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol AppDataManager {
     var onDataUpdate: (() -> Void)? { get set }
-    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void))
+    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Void, NetworkError>) -> Void))
     func getNumberOfArticles() -> Int
     func getTitleForArticle(at index: Int) -> String
     func getDescriptionForArticle(at index: Int) -> String
@@ -55,14 +55,11 @@ final class DataManager: AppDataManager {
 
     // MARK: AppDataManager API
 
-    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void)) {
-        repository.downloadNews(about: keyword, searchCriteria: searchCriteria) { [weak self] result in
-            guard let self else { return }
+    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Void, NetworkError>) -> Void)) {
+        repository.downloadNews(about: keyword, searchCriteria: searchCriteria) { result in
             switch result {
-            case .success(_):
-                onDataUpdate?()
-            case let .failure(error):
-                completion(.failure(error))
+            case .success: completion(.success(()))
+            case let .failure(error): completion(.failure(error))
             }
         }
     }

--- a/NewsCatcher/DataManager/NewsRepository.swift
+++ b/NewsCatcher/DataManager/NewsRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol AppDataRepository {
     func getInitialFeed(completion: @escaping () -> Void)
-    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void))
+    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Void, NetworkError>) -> Void))
     func getNumberOfArticles() -> Int
     func getTitleForArticle(at index: Int) -> String
     func getDescriptionForArticle(at index: Int) -> String
@@ -55,7 +55,7 @@ final class NewsRepository: AppDataRepository {
         }
     }
 
-    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void)) {
+    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Void, NetworkError>) -> Void)) {
         networkService.downloadArticles(about: keyword, searchCriteria: searchCriteria) { [weak self] result in
             guard let self else { return }
 
@@ -63,7 +63,7 @@ final class NewsRepository: AppDataRepository {
             case let .success(articles):
                 self.articles = articles
                 cacheService.save(articles: articles, forKey: Constants.articlesCacheKey)
-                completion(.success(true))
+                completion(.success(()))
             case let .failure(error):
                 completion(.failure(error))
             }

--- a/NewsCatcher/DataManager/NewsRepository.swift
+++ b/NewsCatcher/DataManager/NewsRepository.swift
@@ -61,9 +61,13 @@ final class NewsRepository: AppDataRepository {
 
             switch result {
             case let .success(articles):
-                self.articles = articles
-                cacheService.save(articles: articles, forKey: Constants.articlesCacheKey)
-                completion(.success(()))
+                if !articles.isEmpty {
+                    self.articles = articles
+                    cacheService.save(articles: articles, forKey: Constants.articlesCacheKey)
+                    completion(.success(()))
+                } else {
+                    completion(.failure(.noArticlesFound))
+                }
             case let .failure(error):
                 completion(.failure(error))
             }

--- a/NewsCatcher/DataManager/NewsRepository.swift
+++ b/NewsCatcher/DataManager/NewsRepository.swift
@@ -9,12 +9,12 @@ import Foundation
 
 protocol AppDataRepository {
     func getInitialFeed(completion: @escaping () -> Void)
-    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping () -> Void)
+    func downloadNews(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void))
     func getNumberOfArticles() -> Int
     func getTitleForArticle(at index: Int) -> String
     func getDescriptionForArticle(at index: Int) -> String
     func getContentForArticle(at index: Int) -> String
-    func getImageDataForArticle(at index: Int, completion: @escaping (Data?) -> Void)
+    func getImageDataForArticle(at index: Int, completion: @escaping (Result<Data, NetworkError>) -> Void)
     func getSourceURLForArticle(at index: Int) -> String
     func getSourceNameForArticle(at index: Int) -> String
     func getPublishingDateForArticle(at index: Int) -> String
@@ -49,18 +49,24 @@ final class NewsRepository: AppDataRepository {
         if let cachedArticles = cacheService.getArticles(forKey: Constants.articlesCacheKey) {
             articles = cachedArticles
         } else {
-            downloadNews(about: nil, searchCriteria: nil) {
+            downloadNews(about: nil, searchCriteria: nil) { _ in
                 completion()
             }
         }
     }
 
-    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping () -> Void) {
-        networkService.downloadArticles(about: keyword, searchCriteria: searchCriteria) { [weak self] articles in
+    func downloadNews(about keyword: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<Bool, NetworkError>) -> Void)) {
+        networkService.downloadArticles(about: keyword, searchCriteria: searchCriteria) { [weak self] result in
             guard let self else { return }
-            self.articles = articles
-            cacheService.save(articles: articles, forKey: Constants.articlesCacheKey)
-            completion()
+
+            switch result {
+            case let .success(articles):
+                self.articles = articles
+                cacheService.save(articles: articles, forKey: Constants.articlesCacheKey)
+                completion(.success(true))
+            case let .failure(error):
+                completion(.failure(error))
+            }
         }
     }
 
@@ -80,15 +86,19 @@ final class NewsRepository: AppDataRepository {
         articles[index].content
     }
 
-    func getImageDataForArticle(at index: Int, completion: @escaping (Data?) -> Void) {
+    func getImageDataForArticle(at index: Int, completion: @escaping (Result<Data, NetworkError>) -> Void) {
         let imageURL = articles[index].imageStringURL
         if let imageData = cacheService.getData(forKey: imageURL) {
-            completion(imageData)
+            completion(.success(imageData))
         } else {
-            networkService.downloadData(from: imageURL) { imageData in
-                guard let imageData = imageData else { return }
-                self.cacheService.save(imageData, forKey: imageURL)
-                completion(imageData)
+            networkService.downloadImageData(from: imageURL) { response in
+                switch response {
+                case let .success(imageData):
+                    self.cacheService.save(imageData, forKey: imageURL)
+                    completion(.success(imageData))
+                case let .failure(error):
+                    completion(.failure(error))
+                }
             }
         }
     }

--- a/NewsCatcher/FeedModule/FeedPresenter.swift
+++ b/NewsCatcher/FeedModule/FeedPresenter.swift
@@ -38,9 +38,10 @@ final class FeedPresenter: FeedOutput {
         if !searchPhrase.isEmpty {
             dataManager.downloadNews(about: searchPhrase, searchCriteria: nil) { result in
                 switch result {
+                case .success(_):
+                    return
                 case let .failure(error):
                     self.handleError(error)
-                default: return
                 }
             }
         }
@@ -52,14 +53,15 @@ final class FeedPresenter: FeedOutput {
     }
 
     func refreshTableViewData() {
+        // TODO: searchCriteria and keyword must be sent in future implementation to save current request properties.
         dataManager.downloadNews(about: nil, searchCriteria: nil) { result in
             switch result {
+            case .success(_):
+                return
             case let .failure(error):
                 self.handleError(error)
-            default: return
             }
         }
-        // TODO: searchCriteria and keyword must be sent in future implementation to save current request properties.
     }
 
     func getNumberOfRowsInSection() -> Int {
@@ -75,12 +77,14 @@ final class FeedPresenter: FeedOutput {
     }
 
     func getImageData(at indexPath: IndexPath, completion: @escaping (Data?) -> Void) {
-        dataManager.getImageDataForArticle(at: indexPath.row) { result in
+        dataManager.getImageDataForArticle(at: indexPath.row) { [weak self] result in
+            guard let self else { return }
+
             switch result {
             case let .success(imageData):
                 completion(imageData)
             case let .failure(error):
-                self.handleError(error)
+                handleError(error)
                 completion(nil)
             }
         }

--- a/NewsCatcher/FeedModule/FeedPresenter.swift
+++ b/NewsCatcher/FeedModule/FeedPresenter.swift
@@ -36,12 +36,11 @@ final class FeedPresenter: FeedOutput {
     func searchButtonTapped() {
         guard let searchPhrase = view?.getSearchFieldText() else { return }
         if !searchPhrase.isEmpty {
-            dataManager.downloadNews(about: searchPhrase, searchCriteria: nil) { result in
+            dataManager.downloadNews(about: searchPhrase, searchCriteria: nil) { [weak self] result in
+                guard let self else { return }
                 switch result {
-                case .success(_):
-                    return
-                case let .failure(error):
-                    self.handleError(error)
+                case .success: view?.reloadFeedTableView()
+                case let .failure(error): handleError(error)
                 }
             }
         }
@@ -54,12 +53,11 @@ final class FeedPresenter: FeedOutput {
 
     func refreshTableViewData() {
         // TODO: searchCriteria and keyword must be sent in future implementation to save current request properties.
-        dataManager.downloadNews(about: nil, searchCriteria: nil) { result in
+        dataManager.downloadNews(about: nil, searchCriteria: nil) { [weak self] result in
+            guard let self else { return }
             switch result {
-            case .success(_):
-                return
-            case let .failure(error):
-                self.handleError(error)
+            case .success: dataManager.onDataUpdate!()
+            case let .failure(error): handleError(error)
             }
         }
     }

--- a/NewsCatcher/FeedModule/FeedPresenter.swift
+++ b/NewsCatcher/FeedModule/FeedPresenter.swift
@@ -56,7 +56,7 @@ final class FeedPresenter: FeedOutput {
         dataManager.downloadNews(about: nil, searchCriteria: nil) { [weak self] result in
             guard let self else { return }
             switch result {
-            case .success: dataManager.onDataUpdate!()
+            case .success: view?.reloadFeedTableView()
             case let .failure(error): handleError(error)
             }
         }

--- a/NewsCatcher/FeedModule/FeedView/FeedCell.swift
+++ b/NewsCatcher/FeedModule/FeedView/FeedCell.swift
@@ -19,6 +19,7 @@ final class FeedCell: UITableViewCell {
 
     static let reuseIdentifier = "FeedCellIdentifier"
     private var timer: Timer?
+    var id = UUID()
 
     // MARK: Subviews
 

--- a/NewsCatcher/FeedModule/FeedView/FeedViewController.swift
+++ b/NewsCatcher/FeedModule/FeedView/FeedViewController.swift
@@ -90,7 +90,7 @@ final class FeedViewController: UIViewController, FeedViewDelegate, FeedInput {
 
     func reloadFeedTableView() {
         feedView.tableView.reloadData()
-            feedView.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+        scrollTableViewBackToTheTop()
     }
 
     func showArticle(at index: Int, dataManager _: AppDataManager) {
@@ -104,6 +104,14 @@ final class FeedViewController: UIViewController, FeedViewDelegate, FeedInput {
 
     func hideKeyboard() {
         feedView.searchTextField.endEditing(true)
+    }
+}
+
+extension FeedViewController {
+    private func scrollTableViewBackToTheTop() {
+        guard feedView.tableView.numberOfSections > 0,
+              feedView.tableView.numberOfRows(inSection: 0) > 0 else { return }
+        feedView.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
     }
 }
 

--- a/NewsCatcher/FeedModule/FeedView/FeedViewController.swift
+++ b/NewsCatcher/FeedModule/FeedView/FeedViewController.swift
@@ -90,7 +90,7 @@ final class FeedViewController: UIViewController, FeedViewDelegate, FeedInput {
 
     func reloadFeedTableView() {
         feedView.tableView.reloadData()
-        feedView.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+            feedView.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
     }
 
     func showArticle(at index: Int, dataManager _: AppDataManager) {

--- a/NewsCatcher/FeedModule/FeedView/FeedViewController.swift
+++ b/NewsCatcher/FeedModule/FeedView/FeedViewController.swift
@@ -126,13 +126,15 @@ extension FeedViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: FeedCell.reuseIdentifier, for: indexPath) as? FeedCell else {
             return UITableViewCell()
         }
+        let requestID = UUID()
+        cell.id = requestID
         let title = presenter.getTitle(at: indexPath)
         let sourceName = presenter.getSourceName(at: indexPath)
         let date = presenter.getPublishingDate(at: indexPath)
         let description = presenter.getDescription(at: indexPath)
         cell.configure(withTitle: title, sourceName: sourceName, date: date, description: description)
         presenter.getImageData(at: indexPath) { imageData in
-            if let imageData = imageData, let image = UIImage(data: imageData) {
+            if let imageData = imageData, let image = UIImage(data: imageData), cell.id == requestID {
                 cell.setImage(image)
             }
         }

--- a/NewsCatcher/Services/Networking/APIRequestBuilder.swift
+++ b/NewsCatcher/Services/Networking/APIRequestBuilder.swift
@@ -7,22 +7,21 @@
 
 protocol AppRequestBuilder {
     func getURLRequestString(for keyPhrase: String?, searchCriteria: ArticleSearchCriteria?) -> String
-    func getDefaultAPISting() -> String
 }
 
 final class APIRequestBuilder: AppRequestBuilder {
     private enum Constants {
-        static let defaultAPISting = "https://gnews.io/api/v4/search?q=example&lang=en&country=us&max=10&apikey=05119a9d9eec92db2c653876cf3e015c"
+        static let defaultKeyPhrase = "iOS"
         static let searchEndpoint = "https://gnews.io/api/v4/search?q="
         static let apiKey = "05119a9d9eec92db2c653876cf3e015c"
-        static let defaultArticleLanguage = "eng"
+        static let defaultArticleLanguage = "en"
         static let defaultArticlePublicationCountry = "any"
         static let defaultSearchPlaces = "title,description"
         static let defaultSortBy = "publishedAt"
     }
 
     func getURLRequestString(for keyPhrase: String?, searchCriteria: ArticleSearchCriteria?) -> String {
-        guard let keyPhrase = keyPhrase else { return Constants.defaultAPISting }
+        let keyPhrase = keyPhrase ?? Constants.defaultKeyPhrase
         let query = turnIntoAPIQuery(keyPhrase)
         let lang = searchCriteria?.articleLanguage ?? Constants.defaultArticleLanguage
         let country = searchCriteria?.publicationCountry ?? Constants.defaultArticlePublicationCountry
@@ -31,10 +30,6 @@ final class APIRequestBuilder: AppRequestBuilder {
         // swiftlint:disable:next line_length
         let urlRequestString = Constants.searchEndpoint + query + "&lang=\(lang)" + "&country=\(country)" + "&in=\(searchPlaces)" + "&sortby=\(sortBy)" + "&apikey=\(Constants.apiKey)"
         return urlRequestString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? urlRequestString
-    }
-
-    func getDefaultAPISting() -> String {
-        return Constants.defaultAPISting
     }
 
     private func turnIntoAPIQuery(_ keyPhrase: String) -> String {

--- a/NewsCatcher/Services/Networking/NetworkError.swift
+++ b/NewsCatcher/Services/Networking/NetworkError.swift
@@ -14,15 +14,9 @@ enum NetworkError: Error {
     case noServerResponse
     case noDataInServerResponse
     case decodingFailed
-    case noArticlesFound
-
-    case badRequest400
-    case unauthorized401
     case forbidden403
-    case tooManyRequests429
-    case internalServerError500
-    case serviceUnavailable503
-    case undefinedServerError
+    case badResponse(statusCode: Int)
+    case noArticlesFound
 
     var localizedDescription: String {
         switch self {
@@ -38,34 +32,12 @@ enum NetworkError: Error {
             return "There is no data in the server response"
         case .decodingFailed:
             return "Decoding Failed"
-        case .noArticlesFound:
-            return "No articles found. Try to change searching phrase"
-        case .badRequest400:
-            return "Your request is invalid. StatusCode: 400"
-        case .unauthorized401:
-            return "Your API key is wrong. StatusCode: 401"
         case .forbidden403:
             return "You have reached your daily quota, the next reset is at 00:00 UTC. StatusCode: 403"
-        case .tooManyRequests429:
-            return "You have made more requests per second than you are allowed. StatusCode: 429"
-        case .internalServerError500:
-            return "We had a problem with our server. Try again later. StatusCode: 500"
-        case .serviceUnavailable503:
-            return "We're temporarily offline for maintenance. Please try again later StatusCode: 503"
-        case .undefinedServerError:
-            return "Undefined Server Error"
-        }
-    }
-
-    static func getInvalidServerResponseError(httpResponse: HTTPURLResponse) -> Self {
-        switch httpResponse.statusCode {
-        case 400: return badRequest400
-        case 401: return unauthorized401
-        case 403: return forbidden403
-        case 429: return tooManyRequests429
-        case 500: return internalServerError500
-        case 503: return serviceUnavailable503
-        default: return undefinedServerError
+        case let .badResponse(statusCode: statusCode):
+            return "There is a bad server response. StatusCode: \(statusCode)"
+        case .noArticlesFound:
+            return "No articles found. Try to change searching phrase"
         }
     }
 }

--- a/NewsCatcher/Services/Networking/NetworkError.swift
+++ b/NewsCatcher/Services/Networking/NetworkError.swift
@@ -1,0 +1,68 @@
+//
+//  NetworkError.swift
+//  NewsCatcher
+//
+//  Created by Юрий Степанчук on 19.09.2023.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case noInternetConnection
+    case requestFailed
+    case noServerResponse
+    case noData
+    case decodingFailed
+
+    case badRequest400
+    case unauthorized401
+    case forbidden403
+    case tooManyRequests429
+    case internalServerError500
+    case serviceUnavailable503
+    case undefinedServerError
+
+    var localizedDescription: String {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .noInternetConnection:
+            return "No Internet Connection"
+        case .requestFailed:
+            return "Request Failed"
+        case .noServerResponse:
+            return "There is no response from the server"
+        case .noData:
+            return "There is no data in the server response"
+        case .decodingFailed:
+            return "Decoding Failed"
+        case .badRequest400:
+            return "Your request is invalid. StatusCode: 400"
+        case .unauthorized401:
+            return "Your API key is wrong. StatusCode: 401"
+        case .forbidden403:
+            return "You have reached your daily quota, the next reset is at 00:00 UTC. StatusCode: 403"
+        case .tooManyRequests429:
+            return "You have made more requests per second than you are allowed. StatusCode: 429"
+        case .internalServerError500:
+            return "We had a problem with our server. Try again later. StatusCode: 500"
+        case .serviceUnavailable503:
+            return "We're temporarily offline for maintenance. Please try again later StatusCode: 503"
+        case .undefinedServerError:
+            return "Undefined Server Error"
+        }
+    }
+
+    static func getInvalidServerResponseError(httpResponse: HTTPURLResponse) -> Self {
+        switch httpResponse.statusCode {
+        case 400: return badRequest400
+        case 401: return unauthorized401
+        case 403: return forbidden403
+        case 429: return tooManyRequests429
+        case 500: return internalServerError500
+        case 503: return serviceUnavailable503
+        default: return undefinedServerError
+        }
+    }
+}

--- a/NewsCatcher/Services/Networking/NetworkError.swift
+++ b/NewsCatcher/Services/Networking/NetworkError.swift
@@ -12,8 +12,9 @@ enum NetworkError: Error {
     case noInternetConnection
     case requestFailed
     case noServerResponse
-    case noData
+    case noDataInServerResponse
     case decodingFailed
+    case noArticlesFound
 
     case badRequest400
     case unauthorized401
@@ -33,10 +34,12 @@ enum NetworkError: Error {
             return "Request Failed"
         case .noServerResponse:
             return "There is no response from the server"
-        case .noData:
+        case .noDataInServerResponse:
             return "There is no data in the server response"
         case .decodingFailed:
             return "Decoding Failed"
+        case .noArticlesFound:
+            return "No articles found. Try to change searching phrase"
         case .badRequest400:
             return "Your request is invalid. StatusCode: 400"
         case .unauthorized401:

--- a/NewsCatcher/Services/Networking/NetworkService.swift
+++ b/NewsCatcher/Services/Networking/NetworkService.swift
@@ -31,11 +31,13 @@ final class NetworkService: AppNetworkService {
             switch dataFetchingResult {
             case let .success(data):
                 parseNews(from: data) { decodingResult in
-                    switch decodingResult {
-                    case let .success(news):
-                        DispatchQueue.main.async { completion(.success(news.articles)) }
-                    case let .failure(error):
-                        DispatchQueue.main.async { completion(.failure(error)) }
+                    DispatchQueue.main.async {
+                        switch decodingResult {
+                        case let .success(news):
+                            completion(.success(news.articles))
+                        case let .failure(error):
+                            completion(.failure(error))
+                        }
                     }
                 }
             case let .failure(error):
@@ -46,11 +48,13 @@ final class NetworkService: AppNetworkService {
 
     func downloadImageData(from urlString: String, completion: @escaping (Result<Data, NetworkError>) -> Void) {
         fetchData(from: urlString) { result in
-            switch result {
-            case let .success(imageData):
-                DispatchQueue.main.async { completion(.success(imageData)) }
-            case let .failure(error):
-                DispatchQueue.main.async { completion(.failure(error)) }
+            DispatchQueue.main.async {
+                switch result {
+                case let .success(imageData):
+                    completion(.success(imageData))
+                case let .failure(error):
+                    completion(.failure(error))
+                }
             }
         }
     }

--- a/NewsCatcher/Services/Networking/NetworkService.swift
+++ b/NewsCatcher/Services/Networking/NetworkService.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 protocol AppNetworkService {
-    func downloadArticles(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ([Article]) -> Void)
-    func downloadData(from url: String, completion: @escaping (Data?) -> Void)
+    func downloadArticles(about: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ((Result<[Article], NetworkError>) -> Void))
+    func downloadImageData(from urlString: String, completion: @escaping (Result<Data, NetworkError>) -> Void)
 }
 
 final class NetworkService: AppNetworkService {
@@ -23,49 +23,88 @@ final class NetworkService: AppNetworkService {
 
     // MARK: AppNetworkManager
 
-    func downloadArticles(about keyPhrase: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping ([Article]) -> Void) {
+    func downloadArticles(about keyPhrase: String?, searchCriteria: ArticleSearchCriteria?, completion: @escaping (Result<[Article], NetworkError>) -> Void) {
         let urlRequestString = apiRequestBuilder.getURLRequestString(for: keyPhrase, searchCriteria: searchCriteria)
-        fetchData(from: urlRequestString) { [weak self] jsonData in
+        fetchData(from: urlRequestString) { [weak self] dataFetchingResult in
             guard let self else { return }
-            self.parseNews(from: jsonData) { news in
-                DispatchQueue.main.async {
-                    completion(news.articles)
+
+            switch dataFetchingResult {
+            case let .success(data):
+                parseNews(from: data) { decodingResult in
+                    switch decodingResult {
+                    case let .success(news):
+                        DispatchQueue.main.async { completion(.success(news.articles)) }
+                    case let .failure(error):
+                        DispatchQueue.main.async { completion(.failure(error)) }
+                    }
                 }
+            case let .failure(error):
+                DispatchQueue.main.async { completion(.failure(error)) }
             }
         }
     }
 
-    func downloadData(from url: String, completion: @escaping (Data?) -> Void) {
-        guard let url = URL(string: url) else { return }
-        let request = URLRequest(url: url)
-        let dataTask = URLSession.shared.dataTask(with: request) { data, _, _ in
-            if let data = data {
-                DispatchQueue.main.async {
-                    completion(data)
-                }
+    func downloadImageData(from urlString: String, completion: @escaping (Result<Data, NetworkError>) -> Void) {
+        fetchData(from: urlString) { result in
+            switch result {
+            case let .success(imageData):
+                DispatchQueue.main.async { completion(.success(imageData)) }
+            case let .failure(error):
+                DispatchQueue.main.async { completion(.failure(error)) }
+            }
+        }
+    }
+
+    // MARK: Private Methods
+
+    private func fetchData(from urlString: String, completion: @escaping (Result<Data, NetworkError>) -> Void) {
+        guard let url = URL(string: urlString) else {
+            completion(.failure(NetworkError.invalidURL))
+            return
+        }
+
+        let dataTask = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                self.handleNetworkError(error, completion)
+            } else {
+                self.handleHTTPResponse(response, data, completion)
             }
         }
         dataTask.resume()
     }
 
-    // MARK: Private Methods
-
-    private func fetchData(from url: String, completion: @escaping (Data) -> Void) {
-        guard let url = URL(string: url) else { return }
-        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
-            guard let data = data else { return }
-            completion(data)
+    private func handleNetworkError(_ error: Error, _ completion: @escaping (Result<Data, NetworkError>) -> Void) {
+        if let error = error as NSError?, error.code == NSURLErrorNotConnectedToInternet {
+            completion(.failure(NetworkError.noInternetConnection))
+        } else {
+            completion(.failure(NetworkError.requestFailed))
         }
-        task.resume()
     }
 
-    private func parseNews(from data: Data, completion: @escaping (News) -> Void) {
+    private func handleHTTPResponse(_ response: URLResponse?, _ data: Data?, _ completion: @escaping (Result<Data, NetworkError>) -> Void) {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            completion(.failure(NetworkError.noServerResponse))
+            return
+        }
+
+        if httpResponse.statusCode == 200 {
+            if let data = data {
+                completion(.success(data))
+            } else {
+                completion(.failure(NetworkError.noData))
+            }
+        } else {
+            completion(.failure(NetworkError.getInvalidServerResponseError(httpResponse: httpResponse)))
+        }
+    }
+
+    private func parseNews(from data: Data, completion: @escaping (Result<News, NetworkError>) -> Void) {
         let decoder = JSONDecoder()
         do {
             let news = try decoder.decode(News.self, from: data)
-            completion(news)
+            completion(.success(news))
         } catch {
-            debugPrint(error)
+            completion(.failure(NetworkError.decodingFailed))
         }
     }
 }

--- a/NewsCatcher/Services/Networking/NetworkService.swift
+++ b/NewsCatcher/Services/Networking/NetworkService.swift
@@ -95,7 +95,7 @@ final class NetworkService: AppNetworkService {
             if let data = data {
                 completion(.success(data))
             } else {
-                completion(.failure(NetworkError.noData))
+                completion(.failure(NetworkError.noDataInServerResponse))
             }
         } else {
             completion(.failure(NetworkError.getInvalidServerResponseError(httpResponse: httpResponse)))

--- a/NewsCatcher/Supporting Files/Base.lproj/LaunchScreen.storyboard
+++ b/NewsCatcher/Supporting Files/Base.lproj/LaunchScreen.storyboard
@@ -18,8 +18,8 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pl0-gJ-VW4">
-                                <rect key="frame" x="138.33333333333334" y="409.33333333333331" width="116.66666666666666" height="33.666666666666686"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                <rect key="frame" x="154" y="414" width="85.333333333333314" height="24"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>


### PR DESCRIPTION
**Добавил обработку ошибок в NetworService.**
Обработку решил сделать через Result.
Возникающие ошибки пробрасываются до слоя Presenter и обрабатываются уже там через switch (сейчас стоит заглушка).

Удалил метод downloadData(from... дублирующий функционал fetchData(from. Последний разложил на несколько методов с обработкой ответа, чтобы было читабельнее.

**Cомневаюсь касательно двух моментов:**
**1. В NetworkService.swift / Строка 26 / func downloadArticles(about...**
Получается switch, вложенный в case другого switch. Не слишком ли громоздко / сложно для понимания?

**2. В DataManager.swift.swift / Строка 58 / func downloadNews(about...**
Я не менял существующую логику, по которой в случае успешного обновления триггерился метод onDataUpdate(), которому назначается действие в Presenter (обновлене таблицы). Но в случае .failure мне все-равно нужно пробросить ошибку в presenter. Тогда приходится обрабатывать только 1 кейс ошибки и передавать какой-то тип (Bool) Result<Bool, NetworkError>), который никак не обрабатывается. 

Мне кажется, что можно убрать onDataUpdate из этого метода и в случае .success обновлять таблицу ужу в Presenter. Это даст большую гибкость, но остатся вопрос: с неиспользуемым типом Bool, который пробрасывается из репозитория в презентер...
